### PR TITLE
add appointments module

### DIFF
--- a/src/appointments.ts
+++ b/src/appointments.ts
@@ -1,0 +1,70 @@
+import type { $Fetch } from "ofetch"
+import type { Openmagicline as mgl } from "."
+
+import type { Magicline, OMGL } from "../types"
+
+export default class Appointments {
+	constructor(
+		private fetch: $Fetch,
+		private mgl: mgl,
+	) {}
+
+	private readonly defaultSearchOptions: OMGL.Appointments.SearchOptions = {
+		appointmentStatuses: ["PLANNED", "COMPLETED"],
+	}
+
+	/**
+	 * search for appointments within a date range.
+	 *
+	 * defaults to the current week (Monday to Sunday) if no dates are provided.
+	 */
+	search = async (options?: Partial<OMGL.Appointments.SearchOptions>) => {
+		const organizationUnitId =
+			options?.organizationUnitId ?? (await this.mgl.unitID)
+
+		const startDate = options?.startDate ?? defaultStartDate()
+		const endDate = options?.endDate ?? defaultEndDate(startDate)
+
+		return await this.fetch<Magicline.Appointments.Appointment[]>(
+			"/newappointments/search",
+			{
+				query: {
+					...this.defaultSearchOptions,
+					...options,
+					organizationUnitId,
+					facilityIds: options?.facilityIds ?? organizationUnitId,
+					startDate,
+					endDate,
+					appointmentStatuses: (
+						options?.appointmentStatuses ??
+						this.defaultSearchOptions.appointmentStatuses
+					)?.join(","),
+				},
+			},
+		)
+	}
+
+	/** get a single appointment by its database ID. */
+	get = async (appointmentId: number) => {
+		return await this.fetch<Magicline.Appointments.Appointment>(
+			`/singleappointments/${appointmentId}`,
+		)
+	}
+}
+
+/** returns the current week's Monday as YYYY-MM-DD */
+function defaultStartDate(): string {
+	const now = new Date()
+	const day = now.getDay()
+	const offset = day === 0 ? -6 : 1 - day
+	const monday = new Date(now)
+	monday.setDate(now.getDate() + offset)
+	return monday.toISOString().slice(0, 10)
+}
+
+/** returns the Sunday after a given start date as YYYY-MM-DD */
+function defaultEndDate(startDate: string): string {
+	const d = new Date(startDate)
+	d.setDate(d.getDate() + 6)
+	return d.toISOString().slice(0, 10)
+}

--- a/src/appointments.ts
+++ b/src/appointments.ts
@@ -45,9 +45,9 @@ export default class Appointments {
 	}
 
 	/** get a single appointment by its database ID. */
-	get = async (appointmentId: number) => {
+	get = async (appointmentId: number, type: "single" | "course" = "single") => {
 		return await this.fetch<Magicline.Appointments.Appointment>(
-			`/singleappointments/${appointmentId}`,
+			`/${type}appointments/${appointmentId}`,
 		)
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import Sales from "./sales"
 import MagicSocket from "./socket"
 import Leads from "./leads"
 import Classes from "./classes"
+import Appointments from "./appointments"
 
 export type { OMGL, Magicline, unitID } from "../types"
 export class Openmagicline {
@@ -63,6 +64,9 @@ export class Openmagicline {
 
 	/** everything related to classes */
 	classes: Classes
+
+	/** everything related to appointments */
+	appointments: Appointments
 
 	/** event handler for magiclines websockets */
 	socket: (unitID?: unitID) => Promise<MagicSocket>
@@ -115,6 +119,7 @@ export class Openmagicline {
 		this.disposal = this.sales
 		this.leads = new Leads(this.fetch, this)
 		this.classes = new Classes(this.fetch, this)
+		this.appointments = new Appointments(this.fetch, this)
 		this.socket = async (unitID) => {
 			const _unitID = unitID ?? (await this.unitID)
 			return new MagicSocket(this, _unitID)

--- a/tests/appointments.test.ts
+++ b/tests/appointments.test.ts
@@ -26,7 +26,15 @@ test("get single appointment", async () => {
 
 	if (!first) return
 
-	const appointment = await instance.appointments.get(first.databaseId)
+	console.log(first)
+
+	const type = first.appointmentType.toLowerCase()
+
+	if (type !== "course" && type !== "single") {
+		throw new Error("invalid appointment type")
+	}
+
+	const appointment = await instance.appointments.get(first.databaseId, type)
 
 	expect(appointment.databaseId).toBe(first.databaseId)
 })

--- a/tests/appointments.test.ts
+++ b/tests/appointments.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import { getInstance } from "./_setup"
+
+const instance = await getInstance()
+
+test("search appointments", async () => {
+	const appointments = await instance.appointments.search()
+
+	expect(appointments.length).toBeTruthy()
+	expect(appointments[0]?.databaseId).toBeTruthy()
+	expect(appointments[0]?.startDateTime).toBeTruthy()
+})
+
+test("search appointments with custom date range", async () => {
+	const appointments = await instance.appointments.search({
+		startDate: "2026-03-30",
+		endDate: "2026-04-05",
+	})
+
+	expect(Array.isArray(appointments)).toBeTrue()
+})
+
+test("get single appointment", async () => {
+	const appointments = await instance.appointments.search()
+	const first = appointments[0]
+
+	if (!first) return
+
+	const appointment = await instance.appointments.get(first.databaseId)
+
+	expect(appointment.databaseId).toBe(first.databaseId)
+})

--- a/types/magicline/appointments.d.ts
+++ b/types/magicline/appointments.d.ts
@@ -1,0 +1,67 @@
+export type AppointmentStatus = "PLANNED" | "COMPLETED" | "CANCELLED"
+
+export type AppointmentSource = "MYSPORTS" | "INTERNAL_API" | "STUDIO"
+
+export type AppointmentVisualType =
+	| "SINGLE_APPOINTMENT_WITHOUT_SERIES"
+	| "SINGLE_APPOINTMENT_WITH_SERIES"
+
+export type AppointmentType = "SINGLE"
+
+export type DescriptionType =
+	| "CUSTOMERS"
+	| "BENEFIT"
+	| "EQUIPMENTS"
+	| "STUDIO"
+	| "EVENT"
+	| "NOTE"
+
+export interface Description {
+	description: string
+	type: DescriptionType
+}
+
+export interface AppointmentCustomer {
+	databaseId: number
+	optlock: number
+	fkOrganizationUnit: number
+	firstname: string
+	lastname: string
+}
+
+export interface Appointment {
+	databaseId: number
+	optlock: number
+	fkOrganizationUnit: number
+	startDateTime: string
+	endDateTime: string
+	colorHex: string
+	descriptions: Description[]
+	type: string
+	label: string | null
+	usageSource: string | null
+	abbreviation: string | null
+	benefit: unknown | null
+	employees: unknown[]
+	resourceIds: number[]
+	appointmentVisualType: AppointmentVisualType
+	resourceStatus: string
+	appointmentStatus: AppointmentStatus
+	appointmentSource: AppointmentSource | null
+	bookingSource: string | null
+	appointmentType: AppointmentType
+	studioOpen: boolean
+	pendingContract: unknown | null
+	bookedParticipants: number
+	maxParticipants: number
+	nonBookedParticipants: number
+	customers: AppointmentCustomer[]
+	hasNoexcuseCustomers: boolean
+	cancelationType: string
+	appointmentMeetingType: string
+	currentCustomerParticipantStatus: unknown | null
+	customerOnWaitingList: boolean
+	customerParticipating: number
+	customerNotParticipating: number
+	customerUnset: number
+}

--- a/types/magicline/index.d.ts
+++ b/types/magicline/index.d.ts
@@ -4,6 +4,7 @@ export * as Sales from "./sales"
 export * as Socket from "./socket"
 export * as Leads from "./leads"
 export * as Classes from "./classes"
+export * as Appointments from "./appointments"
 
 export type CurrentLocale = string
 export type SupportedLocales = string[]

--- a/types/openmagicline/appointments.d.ts
+++ b/types/openmagicline/appointments.d.ts
@@ -1,0 +1,13 @@
+import type { unitID } from ".."
+import type { AppointmentStatus } from "../magicline/appointments"
+
+export type SearchOptions = {
+	organizationUnitId?: unitID
+	/** defaults to today */
+	startDate?: string
+	/** defaults to 7 days from startDate */
+	endDate?: string
+	/** defaults to ["PLANNED", "COMPLETED"] */
+	appointmentStatuses?: AppointmentStatus[]
+	facilityIds?: unitID
+}

--- a/types/openmagicline/index.d.ts
+++ b/types/openmagicline/index.d.ts
@@ -4,6 +4,7 @@ export * as Customer from "./customer"
 export * as Checkin from "./checkin"
 export * as Sales from "./sales"
 export * as Classes from "./classes"
+export * as Appointments from "./appointments"
 
 export interface Config {
 	/**


### PR DESCRIPTION
  ## Summary        
  - Adds an `appointments` module for searching and fetching calendar/appointment data
  - `search()` — queries `GET /newappointments/search` with date range, status filtering, and facility scoping (defaults to current week)
  - `get()` — fetches a single appointment by ID via `GET /singleappointments/:id`        
  - Full response types based on real API responses

  ## Usage
  ```typescript     
  const appointments = await mgl.appointments.search({      
    startDate: "2026-04-01",  
    endDate: "2026-04-07",    
    appointmentStatuses: ["PLANNED", "COMPLETED"],
  })      

  const single = await mgl.appointments.get(1222261312)     
   
  Files   

  - src/appointments.ts — module class
  - types/magicline/appointments.d.ts — response types
  - types/openmagicline/appointments.d.ts — request option types      
  - tests/appointments.test.ts — tests
  - src/index.ts, types/*/index.d.ts — wiring